### PR TITLE
Add drag-and-drop UI for spell order

### DIFF
--- a/Assets/_Noitero/Scripts/Player/PlayerWeaponController.cs
+++ b/Assets/_Noitero/Scripts/Player/PlayerWeaponController.cs
@@ -7,6 +7,8 @@ public class PlayerWeaponController : MonoBehaviour
     private WeaponInstance weaponInstance;
     private Camera mainCamera;
 
+    public WeaponInstance WeaponInstance => weaponInstance;
+
     void Start()
     {
         weaponInstance = new WeaponInstance(weaponData, casterTransform, this);

--- a/Assets/_Noitero/Scripts/UI/SpellListUI.cs
+++ b/Assets/_Noitero/Scripts/UI/SpellListUI.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SpellListUI : MonoBehaviour
+{
+    [SerializeField] private PlayerWeaponController weaponController;
+    [SerializeField] private Transform content;
+    [SerializeField] private GameObject spellSlotPrefab;
+
+    private List<SpellSlotUI> slots = new();
+
+    private void Start()
+    {
+        if (weaponController == null || content == null || spellSlotPrefab == null)
+            return;
+
+        var instance = weaponController.WeaponInstance;
+        if (instance == null)
+            return;
+
+        for (int i = 0; i < instance.SpellSequence.Count; i++)
+        {
+            var slotGO = Instantiate(spellSlotPrefab, content);
+            var slot = slotGO.GetComponent<SpellSlotUI>();
+            slot.Setup(this, instance.SpellSequence[i], i);
+            slots.Add(slot);
+        }
+    }
+
+    public void OnItemMoved(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex)
+            return;
+
+        var instance = weaponController.WeaponInstance;
+        instance.MoveSpell(oldIndex, newIndex);
+
+        var slot = slots[oldIndex];
+        slots.RemoveAt(oldIndex);
+        slots.Insert(newIndex, slot);
+
+        for (int i = 0; i < slots.Count; i++)
+        {
+            slots[i].UpdateIndex(i);
+        }
+    }
+}

--- a/Assets/_Noitero/Scripts/UI/SpellListUI.cs.meta
+++ b/Assets/_Noitero/Scripts/UI/SpellListUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 953aee5ef0aa4a7db1451b115f809287
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Noitero/Scripts/UI/SpellSlotUI.cs
+++ b/Assets/_Noitero/Scripts/UI/SpellSlotUI.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+public class SpellSlotUI : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+    [SerializeField] private Text label;
+
+    private RectTransform rectTransform;
+    private CanvasGroup canvasGroup;
+    private Transform parentAfterDrag;
+    private GameObject placeholder;
+    private SpellListUI listUI;
+    private int index;
+
+    public void Setup(SpellListUI list, SpellBase spell, int index)
+    {
+        listUI = list;
+        this.index = index;
+        if (label != null)
+            label.text = spell.name;
+    }
+
+    public void UpdateIndex(int newIndex)
+    {
+        index = newIndex;
+    }
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        rectTransform = GetComponent<RectTransform>();
+        canvasGroup = GetComponent<CanvasGroup>();
+        if (canvasGroup != null)
+            canvasGroup.blocksRaycasts = false;
+
+        parentAfterDrag = transform.parent;
+        placeholder = new GameObject("placeholder");
+        var layout = placeholder.AddComponent<LayoutElement>();
+        layout.preferredWidth = rectTransform.rect.width;
+        layout.preferredHeight = rectTransform.rect.height;
+        placeholder.transform.SetParent(parentAfterDrag);
+        placeholder.transform.SetSiblingIndex(transform.GetSiblingIndex());
+
+        transform.SetParent(parentAfterDrag.parent);
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        if (rectTransform != null)
+            rectTransform.position = eventData.position;
+
+        for (int i = 0; i < parentAfterDrag.childCount; i++)
+        {
+            var child = parentAfterDrag.GetChild(i);
+            if (rectTransform.position.x < child.position.x)
+            {
+                placeholder.transform.SetSiblingIndex(i);
+                break;
+            }
+        }
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        if (canvasGroup != null)
+            canvasGroup.blocksRaycasts = true;
+
+        transform.SetParent(parentAfterDrag);
+        int newIndex = placeholder.transform.GetSiblingIndex();
+        transform.SetSiblingIndex(newIndex);
+
+        listUI.OnItemMoved(index, newIndex);
+
+        Destroy(placeholder);
+    }
+}

--- a/Assets/_Noitero/Scripts/UI/SpellSlotUI.cs.meta
+++ b/Assets/_Noitero/Scripts/UI/SpellSlotUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b49cdd5097c0450ca41f7a09dcaf8ea4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- expose the `WeaponInstance` from `PlayerWeaponController`
- allow changing order of spells in `WeaponInstance`
- create `SpellListUI` and `SpellSlotUI` for displaying and reordering spells

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684adc0894fc832a886530d21bd03f9d