### PR TITLE
Add creative spell projectiles and modifiers

### DIFF
--- a/Assets/_Noitero/Scripts/Spells/Effects/LaserSpell.cs
+++ b/Assets/_Noitero/Scripts/Spells/Effects/LaserSpell.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Spells/Effect/Laser")]
+public class LaserSpell : SpellBase
+{
+    [SerializeField] private float length = 10f;
+    [SerializeField] private int damage = 5;
+
+    public override void Execute(SpellExecutionContext context)
+    {
+        Vector3 start = context.Caster;
+        Vector3 dir = context.Direction.normalized;
+
+        if (Physics.Raycast(start, dir, out RaycastHit hit, length))
+        {
+            if (hit.collider.TryGetComponent<IHealth>(out var health))
+                health.Damage(damage);
+
+            context.Caster = hit.point;
+        }
+        else
+        {
+            context.Caster = start + dir * length;
+        }
+
+        context.ImpactTriggered = true;
+    }
+}

--- a/Assets/_Noitero/Scripts/Spells/Modificators/DamageMultiplierModifier.cs
+++ b/Assets/_Noitero/Scripts/Spells/Modificators/DamageMultiplierModifier.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Spells/Modifier/Damage Multiplier")]
+public class DamageMultiplierModifier : SpellBase
+{
+    [SerializeField] private float multiplier = 1.5f;
+
+    public override void Execute(SpellExecutionContext context)
+    {
+        foreach (var proj in context.SpawnedProjectiles)
+        {
+            if (proj == null) continue;
+            foreach (var hit in proj.GetComponentsInChildren<TriggerHit>())
+            {
+                hit.MultiplyDamage(multiplier);
+            }
+        }
+    }
+}

--- a/Assets/_Noitero/Scripts/Spells/Modificators/SpeedMultiplierModifier.cs
+++ b/Assets/_Noitero/Scripts/Spells/Modificators/SpeedMultiplierModifier.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Spells/Modifier/Speed Multiplier")]
+public class SpeedMultiplierModifier : SpellBase
+{
+    [SerializeField] private float multiplier = 1.5f;
+
+    public override void Execute(SpellExecutionContext context)
+    {
+        foreach (var proj in context.SpawnedProjectiles)
+        {
+            if (proj == null) continue;
+            var rb = proj.GetComponent<Rigidbody>();
+            if (rb != null)
+            {
+                rb.linearVelocity *= multiplier;
+            }
+        }
+    }
+}

--- a/Assets/_Noitero/Scripts/Spells/Projectilles/ArcProjectileSpell.cs
+++ b/Assets/_Noitero/Scripts/Spells/Projectilles/ArcProjectileSpell.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Spells/Projectile/Arc Projectile")]
+public class ArcProjectileSpell : SpellBase
+{
+    [SerializeField] private GameObject projectilePrefab;
+    [SerializeField] private float speed = 10f;
+    [SerializeField] private float upwardVelocity = 5f;
+
+    public override void Execute(SpellExecutionContext context)
+    {
+        Vector3 spawnPos = context.Caster + context.Direction.normalized * 0.5f;
+        var instance = Instantiate(projectilePrefab, spawnPos, Quaternion.LookRotation(context.Direction));
+
+        if (instance.TryGetComponent<Rigidbody>(out var rb))
+        {
+            Vector3 vel = context.Direction.normalized * speed;
+            vel.y += upwardVelocity;
+            rb.linearVelocity = vel;
+        }
+
+        instance.AddComponent<TriggerHit>().Init(10);
+        context.SpawnedProjectiles.Add(instance);
+
+        if (context.PendingModifiers != null)
+        {
+            foreach (var mod in context.PendingModifiers)
+                mod.Execute(context);
+        }
+    }
+}

--- a/Assets/_Noitero/Scripts/Spells/Projectilles/ProximityMine.cs
+++ b/Assets/_Noitero/Scripts/Spells/Projectilles/ProximityMine.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public class ProximityMine : MonoBehaviour
+{
+    [SerializeField] private float radius = 2f;
+    [SerializeField] private int damage = 10;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.gameObject.TryGetComponent<IHealth>(out _))
+        {
+            Explode();
+        }
+    }
+
+    private void Explode()
+    {
+        Collider[] hits = Physics.OverlapSphere(transform.position, radius);
+        foreach (var h in hits)
+        {
+            if (h.TryGetComponent<IHealth>(out var health))
+            {
+                health.Damage(damage);
+            }
+        }
+        Destroy(gameObject);
+    }
+}

--- a/Assets/_Noitero/Scripts/Spells/Projectilles/ProximityMineSpell.cs
+++ b/Assets/_Noitero/Scripts/Spells/Projectilles/ProximityMineSpell.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Spells/Projectile/Proximity Mine")]
+public class ProximityMineSpell : SpellBase
+{
+    [SerializeField] private GameObject minePrefab;
+
+    public override void Execute(SpellExecutionContext context)
+    {
+        Vector3 spawnPos = context.Caster + context.Direction.normalized * 0.5f;
+        var instance = Instantiate(minePrefab, spawnPos, Quaternion.identity);
+        context.SpawnedProjectiles.Add(instance);
+
+        if (context.PendingModifiers != null)
+        {
+            foreach (var mod in context.PendingModifiers)
+                mod.Execute(context);
+        }
+    }
+}

--- a/Assets/_Noitero/Scripts/Spells/Projectilles/TriggerHit.cs
+++ b/Assets/_Noitero/Scripts/Spells/Projectilles/TriggerHit.cs
@@ -3,6 +3,11 @@ using UnityEngine;
 public class TriggerHit : MonoBehaviour
 {
     private int _damage;
+
+    public void MultiplyDamage(float factor)
+    {
+        _damage = Mathf.RoundToInt(_damage * factor);
+    }
     public void Init(int dmg)
     {
         _damage = dmg;

--- a/Assets/_Noitero/Scripts/Spells/Projectilles/ZigZagProjectile.cs
+++ b/Assets/_Noitero/Scripts/Spells/Projectilles/ZigZagProjectile.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class ZigZagProjectile : MonoBehaviour
+{
+    private float _speed;
+    private Vector3 _direction;
+    private float _amplitude;
+    private float _frequency;
+    private Rigidbody _rb;
+    private Vector3 _right;
+    private float _time;
+
+    public void Init(Vector3 direction, float speed, float amplitude, float frequency)
+    {
+        _direction = direction.normalized;
+        _speed = speed;
+        _amplitude = amplitude;
+        _frequency = frequency;
+        _right = Vector3.Cross(Vector3.up, _direction).normalized;
+        _rb = GetComponent<Rigidbody>();
+        Destroy(gameObject, 5f);
+    }
+
+    private void FixedUpdate()
+    {
+        if (_rb == null) return;
+        _time += Time.fixedDeltaTime;
+        float offset = Mathf.Sin(_time * _frequency) * _amplitude;
+        Vector3 velocity = _direction * _speed + _right * offset;
+        _rb.linearVelocity = velocity;
+    }
+}

--- a/Assets/_Noitero/Scripts/Spells/Projectilles/ZigZagProjectileSpell.cs
+++ b/Assets/_Noitero/Scripts/Spells/Projectilles/ZigZagProjectileSpell.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Spells/Projectile/ZigZag Projectile")]
+public class ZigZagProjectileSpell : SpellBase
+{
+    [SerializeField] private GameObject projectilePrefab;
+    [SerializeField] private float speed = 10f;
+    [SerializeField] private float amplitude = 2f;
+    [SerializeField] private float frequency = 5f;
+
+    public override void Execute(SpellExecutionContext context)
+    {
+        Vector3 spawnPos = context.Caster + context.Direction.normalized * 0.5f;
+        var instance = Instantiate(projectilePrefab, spawnPos, Quaternion.LookRotation(context.Direction));
+
+        var zigzag = instance.AddComponent<ZigZagProjectile>();
+        zigzag.Init(context.Direction, speed, amplitude, frequency);
+
+        instance.AddComponent<TriggerHit>().Init(10);
+        context.SpawnedProjectiles.Add(instance);
+
+        if (context.PendingModifiers != null)
+        {
+            foreach (var mod in context.PendingModifiers)
+                mod.Execute(context);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- let TriggerHit support damage multipliers
- add LaserSpell effect
- implement arc and zigzag projectile spells
- create proximity mine spell and behaviour
- add damage and speed multiplier modifiers

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c17ffa528832a91c41f6eefb9f433