### PR TITLE
Add spell reserve drag-n-drop

### DIFF
--- a/Assets/_Noitero/Scenes/SampleScene.unity
+++ b/Assets/_Noitero/Scenes/SampleScene.unity
@@ -521,6 +521,20 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &406456126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 406456122}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2794031805df47b2b0e1f3a953f8e9e9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  content: {fileID: 406456123}
+  spellSlotPrefab: {fileID: 4111130518046262368, guid: 2e073cae684843643846d7603ff8af2a, type: 3}
 --- !u!1 &410087039
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Noitero/Scripts/Class/WeaponInstance.cs
+++ b/Assets/_Noitero/Scripts/Class/WeaponInstance.cs
@@ -100,6 +100,26 @@ public class WeaponInstance
         _dataSnapshot = new List<SpellBase>(_spellSequence);
     }
 
+    public void RemoveSpellAt(int index)
+    {
+        if (index < 0 || index >= _spellSequence.Count)
+            return;
+        _spellSequence.RemoveAt(index);
+        _data.RemoveSpellAt(index);
+        ResetSpellQueue();
+        _dataSnapshot = new List<SpellBase>(_spellSequence);
+    }
+
+    public void InsertSpell(int index, SpellBase spell)
+    {
+        if (index < 0 || index > _spellSequence.Count)
+            index = _spellSequence.Count;
+        _spellSequence.Insert(index, spell);
+        _data.InsertSpell(index, spell);
+        ResetSpellQueue();
+        _dataSnapshot = new List<SpellBase>(_spellSequence);
+    }
+
     /// <summary>
     /// Attempts to cast the next spell in the queue.
     /// If the queue is empty it will be rebuilt from the sequence.

--- a/Assets/_Noitero/Scripts/ScriptablesClass/WeaponData.cs
+++ b/Assets/_Noitero/Scripts/ScriptablesClass/WeaponData.cs
@@ -28,4 +28,18 @@ public class WeaponData : ScriptableObject
         spellSequence.RemoveAt(oldIndex);
         spellSequence.Insert(newIndex, item);
     }
+
+    public void RemoveSpellAt(int index)
+    {
+        if (index < 0 || index >= spellSequence.Count)
+            return;
+        spellSequence.RemoveAt(index);
+    }
+
+    public void InsertSpell(int index, SpellBase spell)
+    {
+        if (index < 0 || index > spellSequence.Count)
+            index = spellSequence.Count;
+        spellSequence.Insert(index, spell);
+    }
 }

--- a/Assets/_Noitero/Scripts/UI/ISpellList.cs
+++ b/Assets/_Noitero/Scripts/UI/ISpellList.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+public interface ISpellList
+{
+    Transform Content { get; }
+    void OnItemMoved(int oldIndex, int newIndex);
+    SpellBase RemoveSpellAt(int index);
+    void InsertSpellAt(SpellBase spell, int index);
+}

--- a/Assets/_Noitero/Scripts/UI/SpellListUI.cs
+++ b/Assets/_Noitero/Scripts/UI/SpellListUI.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-public class SpellListUI : MonoBehaviour
+public class SpellListUI : MonoBehaviour, ISpellList
 {
     [SerializeField] private PlayerWeaponController weaponController;
     [SerializeField] private Transform content;
@@ -62,15 +62,30 @@ public class SpellListUI : MonoBehaviour
         var instance = weaponController.WeaponInstance;
         instance.MoveSpell(oldIndex, newIndex);
 
-        var slot = slots[oldIndex];
-        slots.RemoveAt(oldIndex);
-        slots.Insert(newIndex, slot);
-
-        for (int i = 0; i < slots.Count; i++)
-        {
-            slots[i].UpdateIndex(i);
-        }
-
         sequenceSnapshot = instance.SpellSequence.ToList();
+        BuildSlots(instance.SpellSequence);
+    }
+
+    public Transform Content => content;
+
+    public SpellBase RemoveSpellAt(int index)
+    {
+        var instance = weaponController.WeaponInstance;
+        if (index < 0 || index >= instance.SpellSequence.Count)
+            return null;
+
+        var spell = instance.SpellSequence[index];
+        instance.RemoveSpellAt(index);
+        sequenceSnapshot = instance.SpellSequence.ToList();
+        BuildSlots(instance.SpellSequence);
+        return spell;
+    }
+
+    public void InsertSpellAt(SpellBase spell, int index)
+    {
+        var instance = weaponController.WeaponInstance;
+        instance.InsertSpell(index, spell);
+        sequenceSnapshot = instance.SpellSequence.ToList();
+        BuildSlots(instance.SpellSequence);
     }
 }

--- a/Assets/_Noitero/Scripts/UI/SpellReserveUI.cs
+++ b/Assets/_Noitero/Scripts/UI/SpellReserveUI.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class SpellReserveUI : MonoBehaviour, ISpellList
+{
+    [SerializeField] private Transform content;
+    [SerializeField] private GameObject spellSlotPrefab;
+    [SerializeField] private List<SpellBase> reserveSpells = new();
+
+    private List<SpellSlotUI> slots = new();
+
+    private void BuildSlots(IReadOnlyList<SpellBase> sequence)
+    {
+        foreach (var slot in slots)
+            Destroy(slot.gameObject);
+        slots.Clear();
+
+        for (int i = 0; i < sequence.Count; i++)
+        {
+            var slotGO = Instantiate(spellSlotPrefab, content);
+            var slot = slotGO.GetComponent<SpellSlotUI>();
+            slot.Setup(this, sequence[i], i);
+            slots.Add(slot);
+        }
+    }
+
+    private void Start()
+    {
+        if (content == null || spellSlotPrefab == null)
+            return;
+
+        BuildSlots(reserveSpells);
+    }
+
+    public Transform Content => content;
+
+    public void OnItemMoved(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex)
+            return;
+
+        var item = reserveSpells[oldIndex];
+        reserveSpells.RemoveAt(oldIndex);
+        reserveSpells.Insert(newIndex, item);
+
+        BuildSlots(reserveSpells);
+    }
+
+    public SpellBase RemoveSpellAt(int index)
+    {
+        if (index < 0 || index >= reserveSpells.Count)
+            return null;
+        var spell = reserveSpells[index];
+        reserveSpells.RemoveAt(index);
+        BuildSlots(reserveSpells);
+        return spell;
+    }
+
+    public void InsertSpellAt(SpellBase spell, int index)
+    {
+        if (index < 0 || index > reserveSpells.Count)
+            index = reserveSpells.Count;
+        reserveSpells.Insert(index, spell);
+        BuildSlots(reserveSpells);
+    }
+}

--- a/Assets/_Noitero/Scripts/UI/SpellReserveUI.cs.meta
+++ b/Assets/_Noitero/Scripts/UI/SpellReserveUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2794031805df47b2b0e1f3a953f8e9e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- allow UI slots to be moved between lists using new `ISpellList` interface
- implement spell reserve container with `SpellReserveUI`
- expand weapon classes to insert/remove spells
- update scene to use reserve list component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c28ea20f4832a9d2adbfc81649b5d